### PR TITLE
259346: Role assignment template for resources like queue and topic

### DIFF
--- a/.azuredevops/publish-helm-library.yaml
+++ b/.azuredevops/publish-helm-library.yaml
@@ -20,7 +20,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: pp/helm-publish
+      ref: main
 
 extends:
   template: /pipelines/common-helm-library-git-publish.yaml@DEFRA-ADPPipelineCommon

--- a/.azuredevops/publish-helm-library.yaml
+++ b/.azuredevops/publish-helm-library.yaml
@@ -20,7 +20,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: main
+      ref: pp/helm-publish
 
 extends:
   template: /pipelines/common-helm-library-git-publish.yaml@DEFRA-ADPPipelineCommon

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In your microservice Helm chart:
   * Issue the following commands to add the repo that contains the library chart, update the repo, then update dependencies in your Helm chart:
 
 ```
-helm repo add adp https://raw.githubusercontent.com/defra/adp-aso-helm-repository/main/
+helm repo add adp https://raw.githubusercontent.com/defra/adp-helm-repository/main/adp-aso-helm-library
 helm repo update
 helm dependency update <helm_chart_location>
 ```
@@ -25,7 +25,7 @@ version: 1.0.0
 dependencies:
 - name: adp-aso-helm-library
   version: ^1.0.0
-  repository: https://raw.githubusercontent.com/defra/adp-aso-helm-repository/master/
+  repository: https://raw.githubusercontent.com/defra/adp-helm-repository/main/adp-aso-helm-library
 ```
 
 NOTE: We will use ACR where ASO Helm Library Chart can be published. So above dependencies will be changed to import library from ACR (In Progress).
@@ -39,10 +39,8 @@ The ASO Helm library chart has been configured using the conventions described i
 The general strategy for using one of the library templates in the parent microservice Helm chart is to create a template for the K8s object formateted as so:
 
 ```
-{{- include "adp-aso-helm-library.namespace-queue" (list . "adp-microservice.namespacesqueue") -}}
-{{- define "adp-microservice.namespacesqueue" -}}
-# Microservice specific configuration in here
-{{- end -}}
+{{- include "adp-aso-helm-library.namespace-queue" . -}}
+
 ```
 
 ### All template required values
@@ -66,7 +64,7 @@ tags:
 
 ### Environment specific Default values 
 
-Below values are set in flux repositories and all ASO resources will use these values internally. 
+The below values are used by the aso templates internally, and their values are set using `platform variables` in `adp-flux-services` repositories.
 
 for e.g. NameSpace Queues will get created inside `serviceBusNamespaceName` namaspace and postgres database will get created inside `postgresServerName` server.
 
@@ -76,6 +74,9 @@ serviceBusResourceGroupName: <string>     --Name of the service bus resource gro
 serviceBusNamespaceName: <string>         --Name of the service bus 
 postgresResourceGroupName: <string>       --Name of the Postgres server resource group
 postgresServerName: <string>              --Name of the postgres server
+teamMIPrefix: <string>                    --Prefix used for ManageIdentity/UserAssignedIdentity resource name
+serviceName: <string>                     --Service name. Suffix used for ManageIdentity/UserAssignedIdentity resource name
+teamResourceGroupName: <string>           --Team ResourceGroup Name where team resources are created.
 ```
 
 ### NameSpace Queue

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ tags:
 
 ### Environment specific Default values 
 
-The below values are used by the aso templates internally, and their values are set using `platform variables` in `adp-flux-services` repositories.
+The below values are used by the ASO templates internally, and their values are set using `platform variables` in `adp-flux-services` repository.
 
 for e.g. NameSpace Queues will get created inside `serviceBusNamespaceName` namaspace and postgres database will get created inside `postgresServerName` server.
 
@@ -113,7 +113,7 @@ namespaceQueues:
 The following values can optionally be set in the parent chart's `values.yaml` to set the other properties for servicebus queues:
 
 `owner` property is used to control the ownership of the queue. The default value is `yes` and you don't need to provide it if you are creating and owning the queue.
-If you are creating only role assignments for the queue you do not owe, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing queue.
+If you are creating only role assignments for the queue you do not own, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing queue.
 
 ```
 namespaceQueues:
@@ -159,7 +159,7 @@ namespaceQueues:
     - roleName: QueueReceiver                    
 ```
 
-If you are creating only role assignments for the queue you do not owe, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing queue. 
+If you are creating only role assignments for the queue you do not own, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing queue. 
 
 For e.g. TeamB wanted to create one role assignments on TeamA's queue, then the template would look like,
 
@@ -205,7 +205,7 @@ namespaceTopics:          <Array of Object>
 The following values can optionally be set in the parent chart's `values.yaml` to set the other properties for `namespaceTopics`:
 
 `owner` property is used to control the ownership of the topic. The default value is `yes` and you don't need to provide it if you are creating and owning the topic.
-If you are only creating role assignments for the topic you do not owe, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing topic.
+If you are only creating role assignments for the topic you do not own, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing topic.
 
 ```
 namespaceTopics:
@@ -248,7 +248,7 @@ namespaceTopics:
     - roleName: TopicReceiver                    
 ```
 
-If you are creating only role assignments for the Topic you do not owe, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing Topic. 
+If you are creating only role assignments for the Topic you do not own, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing Topic. 
 
 For e.g. TeamB wanted to create one role assignments on TeamA's Topic, then the template would look like,
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The following values need to be set in the parent chart's `values.yaml` in addit
 Note that `namespaceQueues` is an array of objects that can be used to create more than one queue.
 
 Please note that the queue name is prefixed with the `namespace` internally. 
-For example, if the namespace name is "adp-demo" and you have provided the queue name as "queue1," then in the service bus, it creates a queue with the "adp-demo-queue1" name.
+For example, if the namespace name is "adp-demo" and you have provided the queue name as "queue1", then in the service bus, it creates a queue with the `adp-demo-queue1` name.
 
 ```
 namespaceQueues:      
@@ -111,9 +111,13 @@ namespaceQueues:
 
 The following values can optionally be set in the parent chart's `values.yaml` to set the other properties for servicebus queues:
 
+`owner` property is used to control the ownership of the queue. The default value is `yes` and you don't need to provide it if you are creating and owning the queue.
+If you are creating only role assignments for the queue you do not owe, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing queue.
+
 ```
 namespaceQueues:
   - name: <string>
+    owner: <string>                                    --Default yes    (Accepted values = yes, no)
     deadLetteringOnMessageExpiration: <bool>           --Default false
     defaultMessageTimeToLive: <string>                 --Default P14D
     duplicateDetectionHistoryTimeWindow: <string>      --Default PT10M
@@ -126,6 +130,44 @@ namespaceQueues:
     maxSizeInMegabytes: <int>                          --Default 1024
     requiresDuplicateDetection: <bool>                 --Default false
     requiresSession: <bool>                            --Default false
+    roleAssignments:
+      - roleName: <string>                             --<RoleName. for e.g QueueSender>
+```
+
+#### NameSpace Queue: RoleAssignments
+
+This template also optionally allows you to create `Role Assignments` by providing `roleAssignments` properties in the namespaceQueues object.
+
+Below are the minimum values that are required to be set in the parent chart's values.yaml to create a `roleAssignments`.
+
+```
+namespaceQueues:      
+  - name: <string>     
+    roleAssignments:                                    <Array of Object> 
+      - roleName: <string>                              <RoleName. for e.g QueueSender>  (Allowed values QueueSender', 'QueueReceiver')
+      - roleName: <string> 
+```
+
+For e.g. TeamA wanted to create a queue called "claim" and add two role assignments, then the template would look like,
+
+```
+namespaceQueues:
+  name: claim
+  roleAssignments:  
+    - roleName: QueueSender
+    - roleName: QueueReceiver                    
+```
+
+If you are creating only role assignments for the queue you do not owe, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing queue. 
+
+For e.g. TeamB wanted to create one role assignments on TeamA's queue, then the template would look like,
+
+```
+namespaceQueues:
+  name: claim
+  owner: 'no'
+  roleAssignments:  
+    - roleName: QueueReceiver                    
 ```
 
 ### NameSpace Topic
@@ -161,10 +203,13 @@ namespaceTopics:          <Array of Object>
 
 The following values can optionally be set in the parent chart's `values.yaml` to set the other properties for `namespaceTopics`:
 
+`owner` property is used to control the ownership of the topic. The default value is `yes` and you don't need to provide it if you are creating and owning the topic.
+If you are only creating role assignments for the topic you do not owe, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing topic.
+
 ```
 namespaceTopics:
   - name: <string>
-    owner: <string>                                    --Default true
+    owner: <string>                                    --Default yes     (Accepted values = yes, no)
     defaultMessageTimeToLive: <string>                 --Default P14D
     duplicateDetectionHistoryTimeWindow: <string>      --Default PT10M
     enableBatchedOperations: <bool>                    --Default true
@@ -174,7 +219,47 @@ namespaceTopics:
     maxSizeInMegabytes: <int>                          --Default 1024
     requiresDuplicateDetection: <bool>                 --Default false
     supportOrdering: <bool>                            --Default true
+    roleAssignments:
+      - roleName: <string>                             --<RoleName. for e.g TopicSender>
 ```
+
+#### NameSpace Topic: RoleAssignments
+
+This template also optionally allows you to create `Role Assignments` by providing `roleAssignments` properties in the namespaceTopics object.
+
+Below are the minimum values that are required to be set in the parent chart's values.yaml to create a `roleAssignments`.
+
+```
+namespaceTopics:      
+  - name: <string>     
+    roleAssignments:                                    <Array of Object> 
+      - roleName: <string>                              <RoleName. for e.g TopicSender>  (Allowed values TopicSender', 'TopicReceiver')
+      - roleName: <string> 
+```
+
+For e.g. TeamA wanted to create a Topic called "calculator" and add two role assignments, then the template would look like,
+
+```
+namespaceTopics:
+  name: calculator
+  roleAssignments:  
+    - roleName: TopicSender
+    - roleName: TopicReceiver                    
+```
+
+If you are creating only role assignments for the Topic you do not owe, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing Topic. 
+
+For e.g. TeamB wanted to create one role assignments on TeamA's Topic, then the template would look like,
+
+```
+namespaceTopics:
+  name: calculator
+  owner: 'no'
+  roleAssignments:  
+    - roleName: TopicReceiver                   
+```
+
+#### NameSpace Topic: Subscriptions, SubscriptionRules
 
 This template also optionally allows you to create `Topic Subscriptions` and `Topic Subscriptions Rules` for a given topic by providing Subscriptions and SubscriptionRules properties in the topic object.
 
@@ -306,19 +391,20 @@ A basic usage of this object template would involve the creation of `templates/u
 
 ```
 
+Please note that the UserAssignedIdentity name is set internally. This value is set in the `adp-flux-services` repository which follows standard naming conventions "{TEAM_MI_PREFIX}-{SERVICE_NAME}". For e.g. In SND1 if the `TEAM_MI_PREFIX` value is set to 'sndadpinfmid1401' and `SERVICE_NAME` value is set to 'adp-demo-service', then `managedIdName` value will be : sndadpinfmid1401-adp-demo-service .
+
+This template uses the below platform variables internally, and you don't need to set them explicitly in the values.yaml file. It must be setup in the `adp-flux-services` repository as a part of the service's ASO helmrelease value configuration.
+- TEAM_MI_PREFIX
+- SERVICE_NAME
+- teamResourceGroupName
+- clusterOIDCIssuerUrl
+
 #### Required values
 
 The following values need to be set in the parent chart's `values.yaml` in addition to the globally required values [listed above](#all-template-required-values).
 
-Please note that the managedIdName name set internally. This value is set in the `adp-flux-services` repository which follows standard naming conventions "{TEAM_MI_PREFIX}-{SERVICE_NAME}". For e.g. In SND1 the `TEAM_MI_PREFIX` value is set to 'sndadpinfmid1401' and `SERVICE_NAME` value set to 'adp-demo-service', the `managedIdName` value will be : sndadpinfmid1401-adp-demo-service .
-
-Apart from that, this template also uses `clusterOIDCIssuerUrl` and `teamResourceGroupName` variables internally to process this template.  
-
-For example, if the UserAssignedIdentity name is "demo-collector-role" then, it creates a UserAssignedIdentity with the "sndadpinfmid1401-demo-collector-role" name.
-
 ```
-userAssignedIdentity:      
-  managedIdName: <string>
+userAssignedIdentity: {}
 
 ```
 

--- a/adp-aso-helm-library/Chart.yaml
+++ b/adp-aso-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-aso-helm-library
 description: A Helm chart library that captures general configuration for Azure Service Operator (ASO) resources.
 type: library
-version: 1.0.8
+version: 1.0.9

--- a/adp-aso-helm-library/Chart.yaml
+++ b/adp-aso-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-aso-helm-library
 description: A Helm chart library that captures general configuration for Azure Service Operator (ASO) resources.
 type: library
-version: 1.0.7
+version: 1.0.8

--- a/adp-aso-helm-library/Chart.yaml
+++ b/adp-aso-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-aso-helm-library
 description: A Helm chart library that captures general configuration for Azure Service Operator (ASO) resources.
 type: library
-version: 1.0.6
+version: 1.0.7

--- a/adp-aso-helm-library/templates/_built-in-roles.tpl
+++ b/adp-aso-helm-library/templates/_built-in-roles.tpl
@@ -1,0 +1,13 @@
+{{/*
+Built In Role: Azure Service Bus Data Receiver
+*/}}
+{{- define "builtInRole.azureServiceBusDataReceiverId" -}}
+{{- printf "%s%s" "/subscriptions/00000000-0000-0000-0000-000000000000" "/providers/Microsoft.Authorization/roleDefinitions/4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0" }}
+{{- end }}
+
+{{/*
+Built In Role: Azure Service Bus Data Sender
+*/}}
+{{- define "builtInRole.azureServiceBusDataSenderId" -}}
+{{- printf "%s%s" "/subscriptions/00000000-0000-0000-0000-000000000000" "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39" }}
+{{- end }}

--- a/adp-aso-helm-library/templates/_federated-credential.yaml
+++ b/adp-aso-helm-library/templates/_federated-credential.yaml
@@ -6,7 +6,7 @@ kind: FederatedIdentityCredential
 metadata:
   {{- $namespaceName := required (printf $requiredMsg "userAssignedIdentity.federatedCred.namespace") $federatedCred.namespace }}
   {{- $serviceAccountName := required (printf $requiredMsg "userAssignedIdentity.federatedCred.serviceAccountName") $federatedCred.serviceAccountName }}
-  {{- $managedIdName := (include "managedidentity.name" $) | lower }}
+  {{- $managedIdName := include "managedidentity.name" $ }}
   name: {{ $managedIdName }}-fic-{{ $index }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace }}
 spec:

--- a/adp-aso-helm-library/templates/_federated-credential.yaml
+++ b/adp-aso-helm-library/templates/_federated-credential.yaml
@@ -6,7 +6,7 @@ kind: FederatedIdentityCredential
 metadata:
   {{- $namespaceName := required (printf $requiredMsg "userAssignedIdentity.federatedCred.namespace") $federatedCred.namespace }}
   {{- $serviceAccountName := required (printf $requiredMsg "userAssignedIdentity.federatedCred.serviceAccountName") $federatedCred.serviceAccountName }}
-  {{- $managedIdName := (required (printf $requiredMsg "userAssignedIdentity.managedIdName") $.Values.userAssignedIdentity.managedIdName) | lower }}
+  {{- $managedIdName := (include "managedidentity.name" $) | lower }}
   name: {{ $managedIdName }}-fic-{{ $index }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace }}
 spec:

--- a/adp-aso-helm-library/templates/_helpers.tpl
+++ b/adp-aso-helm-library/templates/_helpers.tpl
@@ -42,7 +42,11 @@ managedidentity Name. Each service will have one managedidentity and it follows 
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
 {{- $teamMIPrefix := (required (printf $requiredMsg "teamMIPrefix") $.Values.teamMIPrefix) }}
 {{- $serviceName := (required (printf $requiredMsg "serviceName") $.Values.serviceName) }}
+{{- if (and $teamMIPrefix $serviceName) }}
 {{- (printf "%s-%s" $teamMIPrefix $serviceName) | lower }}
+{{- else }}
+{{- printf "this-condition-is-required-for-linting" }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/adp-aso-helm-library/templates/_helpers.tpl
+++ b/adp-aso-helm-library/templates/_helpers.tpl
@@ -39,7 +39,10 @@ resource FullName
 managedidentity Name. Each service will have one managedidentity and it follows standard naming convention which is derived in adp-flux-services
 */}}
 {{- define "managedidentity.name" -}}
-{{- printf "%s-%s" $.Values.teamMIPrefix $.Values.serviceName }}
+{{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
+{{- $teamMIPrefix := (required (printf $requiredMsg "teamMIPrefix") $.Values.teamMIPrefix) }}
+{{- $serviceName := (required (printf $requiredMsg "serviceName") $.Values.serviceName) }}
+{{- (printf "%s-%s" $teamMIPrefix $serviceName) | lower }}
 {{- end }}
 
 {{/*

--- a/adp-aso-helm-library/templates/_helpers.tpl
+++ b/adp-aso-helm-library/templates/_helpers.tpl
@@ -21,3 +21,63 @@ kubernetes_cluster: {{ required (printf $requiredMsg "tags.kubernetes_cluster") 
 kubernetes_namespace: {{ required (printf $requiredMsg "tags.kubernetes_namespace") .Values.namespace | quote }}
 kubernetes_label_ServiceCode: {{ required (printf $requiredMsg "tags.kubernetes_label_ServiceCode") .Values.tags.ServiceCode | quote }}
 {{- end -}}
+
+
+{{/*
+resource FullName
+*/}}
+{{- define "resource.fullname" -}}
+{{- $ := index . 0 }}
+{{- $resourceName := index . 1 }}
+{{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
+{{- $resourceNamePrefix := (required (printf $requiredMsg "namespace") $.Values.namespace) | lower }}
+{{- (printf "%s-%s" $resourceNamePrefix $resourceName) | lower }}
+{{- end }}
+
+
+{{/*
+managedidentity Name. Each service will have one managedidentity and it follows standard naming convention which is derived in adp-flux-services
+*/}}
+{{- define "managedidentity.name" -}}
+{{- printf "%s-%s" $.Values.teamMIPrefix $.Values.serviceName }}
+{{- end }}
+
+{{/*
+managedidentity ConfigMapName
+*/}}
+{{- define "managedidentity.configMapName" -}}
+{{- printf "%s-mi-identity-settings" (include "managedidentity.name" .) }}
+{{- end }}
+
+{{/*
+roleDefinitionId for the roleAssignment
+*/}}
+{{- define "roleAssignment.roleDefinitionId" -}}
+{{- $roleName := . | lower }}
+{{- if eq $roleName "queuesender" }}
+{{- printf (include "builtInRole.azureServiceBusDataSenderId" .) }}
+{{- else if eq $roleName "queuereceiver" }}
+{{- printf (include "builtInRole.azureServiceBusDataReceiverId" .) }}
+{{- else if eq $roleName "topicsender" }}
+{{- printf (include "builtInRole.azureServiceBusDataSenderId" .) }}
+{{- else if eq $roleName "topicreceiver" }}
+{{- printf (include "builtInRole.azureServiceBusDataReceiverId" .) }}
+{{- else }}
+{{- fail (printf "Value for roleName is not as expected. '%s' role is not in the allowed roles." $roleName) }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Scope for the roleAssignment
+*/}}
+{{- define "roleAssignment.scope" -}}
+{{- $ := index . 0 }}
+{{- $resourceName := index . 1 }}
+{{- $resourceType := index . 2 }}
+{{- if eq $resourceType "namespaceQueue" }}
+{{- printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ServiceBus/namespaces/%s/queues/%s" $.Values.subscriptionId $.Values.serviceBusResourceGroupName $.Values.serviceBusNamespaceName $resourceName }}
+{{- else if eq $resourceType "namespaceTopic" }}
+{{- printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ServiceBus/namespaces/%s/topics/%s" $.Values.subscriptionId $.Values.serviceBusResourceGroupName $.Values.serviceBusNamespaceName $resourceName }}
+{{- end }}
+{{- end }}

--- a/adp-aso-helm-library/templates/_namespace-queue.yaml
+++ b/adp-aso-helm-library/templates/_namespace-queue.yaml
@@ -1,19 +1,20 @@
 {{- define "adp-aso-helm-library.namespace-queue" -}}
-{{- range $namespaceQueue := .Values.namespaceQueues }}
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
+{{- range $namespaceQueue := .Values.namespaceQueues }}
+{{- $owner := $namespaceQueue.owner | default "yes" }}
+{{- $queueName := include "resource.fullname" (list $ ((required (printf $requiredMsg "namespaceQueue.name") $namespaceQueue.name) | lower)) }}
+{{- if eq $owner "yes" }}
 apiVersion: servicebus.azure.com/v1api20211101
 kind: NamespacesQueue
-{{- $queueNamePrefix := (required (printf $requiredMsg "namespace") $.Values.namespace) | lower }}
-{{- $queueNameSuffix := (required (printf $requiredMsg "namespaceQueue.name") $namespaceQueue.name) | lower }}
 metadata:
-  name: {{ $queueNamePrefix }}-{{ $queueNameSuffix }}
+  name: {{ $queueName }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace | quote }}  
   {{- with $.Values.asoAnnotations }}
   annotations: 
     {{- toYaml . | nindent 4 }}
   {{- end }}  
 spec:
-  azureName: {{ $queueNamePrefix }}-{{ $queueNameSuffix }}
+  azureName: {{ $queueName }}
   deadLetteringOnMessageExpiration: {{ $namespaceQueue.deadLetteringOnMessageExpiration | default false }}
   defaultMessageTimeToLive: {{ $namespaceQueue.defaultMessageTimeToLive | default "P14D" | quote }} 
   duplicateDetectionHistoryTimeWindow: {{ $namespaceQueue.duplicateDetectionHistoryTimeWindow | default "PT10M" | quote }}  
@@ -31,6 +32,13 @@ spec:
   {{- $serviceBusNamespaceName := required (printf $requiredMsg "serviceBusNamespaceName") $.Values.serviceBusNamespaceName }}
   owner:
     armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ServiceBus/namespaces/%s" $subscriptionId $serviceBusResourceGroupName $serviceBusNamespaceName }} 
----  
+ 
+{{- end }}
+{{- if $namespaceQueue.roleAssignments }}    
+---
+{{- include "adp-aso-helm-library.role-assignment-managed" (list $ $namespaceQueue.roleAssignments $queueName "namespaceQueue") }}  
+{{- else }}
+--- 
+{{- end }}  
 {{- end }}
 {{- end }}

--- a/adp-aso-helm-library/templates/_namespace-topic-subscription-rule.yaml
+++ b/adp-aso-helm-library/templates/_namespace-topic-subscription-rule.yaml
@@ -57,7 +57,7 @@ spec:
   {{- $subscriptionId := required (printf $requiredMsg "subscriptionId") $.Values.subscriptionId }}
   {{- $serviceBusResourceGroupName := required (printf $requiredMsg "serviceBusResourceGroupName") $.Values.serviceBusResourceGroupName }}
   {{- $serviceBusNamespaceName := required (printf $requiredMsg "serviceBusNamespaceName") $.Values.serviceBusNamespaceName }}
-  {{- $serviceBusTopicName := (printf "%s-%s" $.Values.namespace $namespaceTopicName) | lower }}
+  {{- $serviceBusTopicName := include "resource.fullname" (list $ $namespaceTopicName) }}
   {{- $serviceBusTopicSubscriptionName := $topicSubscriptionObj.name | lower }}
   owner:
     armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ServiceBus/namespaces/%s/topics/%s/subscriptions/%s" $subscriptionId $serviceBusResourceGroupName $serviceBusNamespaceName $serviceBusTopicName $serviceBusTopicSubscriptionName }}                     

--- a/adp-aso-helm-library/templates/_namespace-topic-subscription.yaml
+++ b/adp-aso-helm-library/templates/_namespace-topic-subscription.yaml
@@ -31,7 +31,7 @@ spec:
   {{- $subscriptionId := required (printf $requiredMsg "subscriptionId") $.Values.subscriptionId }}
   {{- $serviceBusResourceGroupName := required (printf $requiredMsg "serviceBusResourceGroupName") $.Values.serviceBusResourceGroupName }}
   {{- $serviceBusNamespaceName := required (printf $requiredMsg "serviceBusNamespaceName") $.Values.serviceBusNamespaceName }}
-  {{- $serviceBusTopicName := (printf "%s-%s" $.Values.namespace $namespaceTopicObj.name) | lower }}
+  {{- $serviceBusTopicName := include "resource.fullname" (list $ (required (printf $requiredMsg "namespaceTopic.name") $namespaceTopicObj.name)) }}
   owner:
     armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ServiceBus/namespaces/%s/topics/%s" $subscriptionId $serviceBusResourceGroupName $serviceBusNamespaceName $serviceBusTopicName }}                       
 ---  

--- a/adp-aso-helm-library/templates/_namespace-topic.yaml
+++ b/adp-aso-helm-library/templates/_namespace-topic.yaml
@@ -1,21 +1,20 @@
 {{- define "adp-aso-helm-library.namespace-topic" -}}
+{{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
 {{- range $namespaceTopic := .Values.namespaceTopics }}
 {{- $owner := $namespaceTopic.owner | default "yes" }}
+{{- $topicName := include "resource.fullname" (list $ (required (printf $requiredMsg "namespaceTopic.name") $namespaceTopic.name)) }}
 {{- if eq $owner "yes" }}
-{{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
 apiVersion: servicebus.azure.com/v1api20211101
 kind: NamespacesTopic
-{{- $topicNamePrefix := (required (printf $requiredMsg "namespace") $.Values.namespace) | lower }}
-{{- $topicNameSuffix := (required (printf $requiredMsg "namespaceTopic.name") $namespaceTopic.name) | lower }}
 metadata:
-  name: {{ $topicNamePrefix }}-{{ $topicNameSuffix }}
+  name: {{ $topicName }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace | quote }}  
   {{- with $.Values.asoAnnotations }}
   annotations: 
     {{- toYaml . | nindent 4 }}
   {{- end }}  
 spec:
-  azureName: {{ $topicNamePrefix }}-{{ $topicNameSuffix }}
+  azureName: {{ $topicName }}
   defaultMessageTimeToLive: {{ $namespaceTopic.defaultMessageTimeToLive | default "P14D" | quote }} 
   duplicateDetectionHistoryTimeWindow: {{ $namespaceTopic.duplicateDetectionHistoryTimeWindow | default "PT10M" | quote }}  
   enableBatchedOperations: {{ $namespaceTopic.enableBatchedOperations | default true }}
@@ -29,11 +28,14 @@ spec:
   {{- $serviceBusResourceGroupName := required (printf $requiredMsg "serviceBusResourceGroupName") $.Values.serviceBusResourceGroupName }}
   {{- $serviceBusNamespaceName := required (printf $requiredMsg "serviceBusNamespaceName") $.Values.serviceBusNamespaceName }}
   owner:
-    armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ServiceBus/namespaces/%s" $subscriptionId $serviceBusResourceGroupName $serviceBusNamespaceName }} 
----  
+    armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ServiceBus/namespaces/%s" $subscriptionId $serviceBusResourceGroupName $serviceBusNamespaceName }}  
+---     
 {{- end }}
 {{- if $namespaceTopic.topicSubscriptions }}    
 {{- include "adp-aso-helm-library.namespace-topic-subscription" (list $ .) }}   
+{{- end }} 
+{{- if $namespaceTopic.roleAssignments }}    
+{{- include "adp-aso-helm-library.role-assignment-managed" (list $ $namespaceTopic.roleAssignments $topicName "namespaceTopic") }}   
 {{- end }} 
 {{- end }}
 {{- end }}

--- a/adp-aso-helm-library/templates/_role-assignment-managed.yaml
+++ b/adp-aso-helm-library/templates/_role-assignment-managed.yaml
@@ -1,0 +1,28 @@
+{{- define "adp-aso-helm-library.role-assignment-managed" -}}
+{{- $ := index . 0 }}
+{{- $roleAssignments := index . 1 }}
+{{- $resourceName := index . 2 }}
+{{- $resourceType := index . 3 }}
+{{- range $index, $roleAssignment := $roleAssignments }}
+{{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
+apiVersion: authorization.azure.com/v1api20200801preview
+kind: RoleAssignment
+metadata:
+  {{- $roleAssignmentName := (printf "%s-%s-%s" (include "managedidentity.name" $) $roleAssignment.roleName "rbac") | lower  }}
+  name: {{ $roleAssignmentName }}-{{ $index }}
+  namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace }}
+  {{- with $.Values.asoAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  principalIdFromConfig:
+    name: {{ include "managedidentity.configMapName" $ }} 
+    key: principalId   
+  roleDefinitionReference:   
+    armId: {{ include "roleAssignment.roleDefinitionId" $roleAssignment.roleName }} 
+  owner:
+    armId: {{ include "roleAssignment.scope" (list $ $resourceName $resourceType) }}
+---  
+{{- end }}    
+{{- end }}

--- a/adp-aso-helm-library/templates/_role-assignment.yaml
+++ b/adp-aso-helm-library/templates/_role-assignment.yaml
@@ -5,7 +5,7 @@ apiVersion: authorization.azure.com/v1api20200801preview
 kind: RoleAssignment
 metadata:
   {{- $managedIdName := required (printf $requiredMsg "userAssignedIdentity.managedIdName") $.Values.userAssignedIdentity.managedIdName }}
-  {{- $managedIdConfigMapName :=  printf "%s-mi-identity-settings" $managedIdName }}
+  {{- $managedIdConfigMapName :=  include "managedidentity.configMapName" $ }}
   {{- $roleAssignmentName := (printf "%s-%s-%s" $managedIdName $roleAssignment.name "rbac") | lower  }}
   name: {{ $roleAssignmentName }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace }}

--- a/adp-aso-helm-library/templates/_role-assignment.yaml
+++ b/adp-aso-helm-library/templates/_role-assignment.yaml
@@ -4,7 +4,7 @@
 apiVersion: authorization.azure.com/v1api20200801preview
 kind: RoleAssignment
 metadata:
-  {{- $managedIdName := required (printf $requiredMsg "userAssignedIdentity.managedIdName") $.Values.userAssignedIdentity.managedIdName }}
+  {{- $managedIdName := (include "managedidentity.name" $) }}
   {{- $managedIdConfigMapName :=  include "managedidentity.configMapName" $ }}
   {{- $roleAssignmentName := (printf "%s-%s-%s" $managedIdName $roleAssignment.name "rbac") | lower  }}
   name: {{ $roleAssignmentName }}

--- a/adp-aso-helm-library/templates/_userassignedidentity.yaml
+++ b/adp-aso-helm-library/templates/_userassignedidentity.yaml
@@ -4,7 +4,7 @@ apiVersion: managedidentity.azure.com/v1api20181130
 kind: UserAssignedIdentity
 metadata:
   {{- $managedIdName := required (printf $requiredMsg "userAssignedIdentity.managedIdName") .Values.userAssignedIdentity.managedIdName | lower }}
-  {{- $managedIdConfigMapName :=  printf "%s-mi-identity-settings" $managedIdName }}
+  {{- $managedIdConfigMapName :=  include "managedidentity.configMapName" . }}
   {{- $teamRGName := required (printf $requiredMsg "teamResourceGroupName") .Values.teamResourceGroupName }}
   name: {{ $managedIdName }}
   namespace: {{ required (printf $requiredMsg "namespace") .Values.namespace }}

--- a/adp-aso-helm-library/templates/_userassignedidentity.yaml
+++ b/adp-aso-helm-library/templates/_userassignedidentity.yaml
@@ -3,7 +3,7 @@
 apiVersion: managedidentity.azure.com/v1api20181130
 kind: UserAssignedIdentity
 metadata:
-  {{- $managedIdName := (include "managedidentity.name" .) | lower }}
+  {{- $managedIdName := include "managedidentity.name" . }}
   {{- $managedIdConfigMapName :=  include "managedidentity.configMapName" . }}
   {{- $teamRGName := required (printf $requiredMsg "teamResourceGroupName") .Values.teamResourceGroupName }}
   name: {{ $managedIdName }}

--- a/adp-aso-helm-library/templates/_userassignedidentity.yaml
+++ b/adp-aso-helm-library/templates/_userassignedidentity.yaml
@@ -3,7 +3,7 @@
 apiVersion: managedidentity.azure.com/v1api20181130
 kind: UserAssignedIdentity
 metadata:
-  {{- $managedIdName := required (printf $requiredMsg "userAssignedIdentity.managedIdName") .Values.userAssignedIdentity.managedIdName | lower }}
+  {{- $managedIdName := (include "managedidentity.name" .) | lower }}
   {{- $managedIdConfigMapName :=  include "managedidentity.configMapName" . }}
   {{- $teamRGName := required (printf $requiredMsg "teamResourceGroupName") .Values.teamResourceGroupName }}
   name: {{ $managedIdName }}


### PR DESCRIPTION
- Added generic role assignment template
- Added support to create role assignment at queue and topic level
- Added helper functions for reusability
- readme update 

AB#259346

Queue with Rbac Example 

```
namespaceQueues:
  - name: Testqueue1
    roleAssignments:
      - roleName: 'QueueSender'
      - roleName: 'QueueReceiver'
  - name: Testqueue2
    owner: 'no'
    roleAssignments:
      - roleName: 'QueueReceiver'   - 
```

Topic with Rbac Example 

```
namespaceTopics:
  - name: Topic1
    roleAssignments:
      - roleName: 'TopicSender'
      - roleName: 'TopicReceiver'
    topicSubscriptions:
      - name: topisub44
```