### PR TITLE
306948: Added StorageAccountPrefix to StorageAccount Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ serviceName: <string>                                   --Service name. Suffix u
 teamResourceGroupName: <string>                         --Team ResourceGroup Name where team resources are created
 virtualNetworkResourceGroupName: <string>               --Virtual Network resource group
 virtualNetworkName: <string>                            --Virtual Network name
+storageAccountPrefix: <string>                          --The prefix used for the storage account resource name
 privateEndpointSubnetName: <string>                     --The name of the subnet for the service's private endpoint
 privateEndpointPrefix: <string>                         --The prefix used for the private endpoint resource name
 azrMSTPrivateLinkDNSUKSouthResourceGroupName: <string>  --NOT USED. We need to discuss this further
@@ -494,6 +495,8 @@ The following values need to be set in the parent chart's `values.yaml` in addit
 Note that `storageAccounts` is an array of objects that can be used to create more than one Storage Accounts.
 
 Please note that the storage account name must be unique across Azure.
+storage account name is internally prefixed with the `storageAccountPrefix`.  
+For instance, in the Dev environment, the storageAccountPrefix is configured as `devadpinfst2401`. If you input "claim" as the storage account name, the final storage account name will be `devadpinfst2401claim`.
 
 ```
 storageAccounts:          <Array of Object>
@@ -656,34 +659,38 @@ storageAccounts:
 
 The table below shows the Azure Service Operator (ASO) resource naming convention in Azure and Kubernetes: 
 
-In the example below, the following values are used for demonstration purposes: 
-- TeamNamespaceName = 'ffc-demo'
-- Service-Name = 'ffc-demo-web'
-- MIPrefix = 'sndadpinfmi1401'
-- ManageIdName = 'sndadpinfmi1401-ffc-demo-web'
-- PENamePrefix = 'sndadpinfpe1401'
+In the example below, the following platform values are used for demonstration purposes: 
+- namespace = 'ffc-demo'
+- serviceName = 'ffc-demo-web'
+- teamMIPrefix = 'sndadpinfmi1401'
+- storageAccountPrefix = 'sndadpinfst1401'
+- privateEndpointPrefix = 'sndadpinfpe1401'
+- postgresServerName = 'sndadpdbsps1401'
+- userassignedidentityName = 'sndadpinfmi1401-ffc-demo-web'
+
+And the following user input values are used for demonstration purposes: 
+
 - QueueName = 'queue01'
 - TopicName = 'topic01'
 - TopicSubName = 'topicSub01'
-- PostgresServerName = 'sndadpdbsps1401'
 - DatabaseName = 'claim'
-- StorageAccountName = 'sndxyzinfst1401'
+- StorageAccountName = 'demo'
 
 | Resource Type | Resource Name Format in `Azure` | Resource Name Example in `Azure` | Resource Name Format in `Kubernetes` | Resource Name Example in `Kubernetes`
 | -------- | ------------------ | -------- | ------------------ |------------------ |
-| NamespacesQueue | {TeamNamespaceName}-{QueueName} | ffc-demo-queue01 |	{TeamNamespaceName}-{QueueName} | ffc-demo-queue01 |
-| Queue RoleAssignment | NA | NA |	{ManageIdName}-{QueueName}-{RoleName}-rbac-{index} | sndadpinfmi1401-ffc-demo-web-ffc-demo-queue01-queuereceiver-rbac-0 |
-| NamespacesTopic | {TeamNamespaceName}-{TopicName} | ffc-demo-topic01 |	{TeamNamespaceName}-{TopicName} | ffc-demo-topic01 |
-| NamespacesTopicsSubscription | {TopicSubName} | topicSub01 |	{TeamNamespaceName}-{TopicName}-{TopicSubName}-subscription | ffc-demo-topic01-topicsub01-subscription |
-| Topic RoleAssignment | NA | NA |	{ManageIdName}-{TopicName}-{RoleName}-rbac-{index} | sndadpinfmi1401-ffc-demo-web-ffc-demo-topic01-topicreceiver-rbac-0 |
-| Postgres Database | {TeamNamespaceName}-{DatabaseName} | ffc-demo-claim | {PostgresServerName}-{TeamNamespaceName}-{DatabaseName} | sndadpdbsps1401-ffc-demo-claim |
-| Manage Idenitty | {MIPrefix}-{Service-Name} | sndadpinfmi1401-ffc-demo-web |	{MIPrefix}-{Service-Name} | sndadpinfmi1401-ffc-demo-web |
-| StorageAccount | {StorageAccountName} | sndxyzinfst1401 |	{Service-Name}-{StorageAccountName} | ffc-demo-web-sndxyzinfst1401 |
-| StorageAccountsBlobService | default | default |	{Service-Name}-{StorageAccountName}-default | ffc-demo-web-sndxyzinfst1401-default |
-| StorageAccountsBlobServicesContainer | {ContainerName} | container-01 |	{Service-Name}-{StorageAccountName}-default-{ContainerName} | ffc-demo-web-sndxyzinfst1401-default-container-01 |
-| StorageAccountsTableServicesTable | {TableName} | table01 |	{Service-Name}-{StorageAccountName}-default-{TableName} | ffc-demo-web-sndxyzinfst1401-default-table01 |
-| PrivateEndpoint | {PENamePrefix}-{ResourceName}-{SubResource} | sndadpinfpe1401-sndxyzinfst1401-blob | {PENamePrefix}-{ResourceName}-{SubResource} | sndadpinfpe1401-sndxyzinfst1401-blob |
-| PrivateEndpointsPrivateDnsZoneGroup | default | default |	{PrivateEndpointName}-default | sndadpinfpe1401-sndxyzinfst1401-blob-default |
+| NamespacesQueue | {namespace}-{QueueName} | ffc-demo-queue01 |	{namespace}-{QueueName} | ffc-demo-queue01 |
+| Queue RoleAssignment | NA | NA |	{userassignedidentityName}-{QueueName}-{RoleName}-rbac-{index} | sndadpinfmi1401-ffc-demo-web-ffc-demo-queue01-queuereceiver-rbac-0 |
+| NamespacesTopic | {namespace}-{TopicName} | ffc-demo-topic01 |	{namespace}-{TopicName} | ffc-demo-topic01 |
+| NamespacesTopicsSubscription | {TopicSubName} | topicSub01 |	{namespace}-{TopicName}-{TopicSubName}-subscription | ffc-demo-topic01-topicsub01-subscription |
+| Topic RoleAssignment | NA | NA |	{userassignedidentityName}-{TopicName}-{RoleName}-rbac-{index} | sndadpinfmi1401-ffc-demo-web-ffc-demo-topic01-topicreceiver-rbac-0 |
+| Postgres Database | {namespace}-{DatabaseName} | ffc-demo-claim | {postgresServerName}-{namespace}-{DatabaseName} | sndadpdbsps1401-ffc-demo-claim |
+| Manage Idenitty | {teamMIPrefix}-{serviceName} | sndadpinfmi1401-ffc-demo-web |	{teamMIPrefix}-{serviceName} | sndadpinfmi1401-ffc-demo-web |
+| StorageAccount | {storageAccountPrefix}{StorageAccountName} | sndadpinfst1401demo |	{serviceName}-{StorageAccountName} | ffc-demo-web-sndadpinfst1401demo |
+| StorageAccountsBlobService | default | default |	{serviceName}-{StorageAccountName}-default | ffc-demo-web-sndadpinfst1401demo-default |
+| StorageAccountsBlobServicesContainer | {ContainerName} | container-01 |	{serviceName}-{StorageAccountName}-default-{ContainerName} | ffc-demo-web-sndadpinfst1401demo-default-container-01 |
+| StorageAccountsTableServicesTable | {TableName} | table01 |	{serviceName}-{StorageAccountName}-default-{TableName} | ffc-demo-web-sndadpinfst1401demo-default-table01 |
+| PrivateEndpoint | {privateEndpointPrefix}-{ResourceName}-{SubResource} | sndadpinfpe1401-sndadpinfst1401demo-blob | {privateEndpointPrefix}-{ResourceName}-{SubResource} | sndadpinfpe1401-sndadpinfst1401demo-blob |
+| PrivateEndpointsPrivateDnsZoneGroup | default | default |	{PrivateEndpointName}-default | sndadpinfpe1401-sndadpinfst1401demo-blob-default |
 
 ## Helper templates
 

--- a/README.md
+++ b/README.md
@@ -164,26 +164,29 @@ namespaceQueues:
       - roleName: <string> 
 ```
 
-For e.g. TeamA wanted to create a queue called "claim" and add two role assignments, then the template would look like,
+If you are creating only role assignments for the queue you do not own, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing queue. 
+
+#### Usage examples
+The following section provides usage examples for the Namespace Queues template.
+
+##### Example 1 : ServiceA in TeamA creates queue with 2 role assignments
 
 ```
 namespaceQueues:
   name: claim
   roleAssignments:  
     - roleName: QueueSender
-    - roleName: QueueReceiver                    
+    - roleName: QueueReceiver   
 ```
 
-If you are creating only role assignments for the queue you do not own, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing queue. 
-
-For e.g. TeamB wanted to create one role assignments on TeamA's queue, then the template would look like,
+##### Example 2 : ServiceB in TeamA needs to receive messages from existing `claim` queue. Note that `owner` is set to `no`.
 
 ```
 namespaceQueues:
   name: claim
   owner: 'no'
   roleAssignments:  
-    - roleName: QueueReceiver                    
+    - roleName: QueueReceiver     
 ```
 
 ### NameSpace Topic
@@ -253,27 +256,7 @@ namespaceTopics:
       - roleName: <string> 
 ```
 
-For e.g. TeamA wanted to create a Topic called "calculator" and add two role assignments, then the template would look like,
-
-```
-namespaceTopics:
-  name: calculator
-  roleAssignments:  
-    - roleName: TopicSender
-    - roleName: TopicReceiver                    
-```
-
-If you are creating only role assignments for the Topic you do not own, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing Topic. 
-
-For e.g. TeamB wanted to create one role assignments on TeamA's Topic, then the template would look like,
-
-```
-namespaceTopics:
-  name: calculator
-  owner: 'no'
-  roleAssignments:  
-    - roleName: TopicReceiver                   
-```
+If you are creating only role assignments for the Topic you do not own, then you should explicitly set the `owner` flag to `no` so that it will only create the role assignments on the existing Topic (See Example 2 in Usage examples section). 
 
 #### NameSpace Topic: Subscriptions, SubscriptionRules
 
@@ -294,36 +277,7 @@ namespaceTopics:
 
 ```
 
-For e.g. The below example will create one topic, one subscription, and two subscription rules.
-
-```
-
-namespaceTopics:
-- name: demo-topic-01
-  topicSubscriptions:
-    - name: demo-topic-subscription-01
-      topicSubscriptionRules:
-        - name: demo-topic-subscription-rule-01
-          filterType: SqlFilter
-          sqlFilter:
-            sqlExpression: "3=3"   
-        - name: demo-topic-subscription-rule-02
-          filterType: CorrelationFilter
-          sqlFilter:
-            contentType: "testvalue"             
-                    
-```
-To create `topicSubscriptions` inside already existing topics, set the property `owner` to `no`. By default `owner` is set to `yes` which creates the topic name defined in values.
-
-Below example creates only the topicSubscriptions inside the existing topic named demo-topic-01.
-
-```
-namespaceTopics:
-- name: demo-topic-01
-  owner: "no"
-  topicSubscriptions:
-    - name: demo-topic-subscription-01
-```
+To create `topicSubscriptions` inside already existing topics, set the property `owner` to `no`. By default `owner` is set to `yes` which creates the topic name defined in values (See Example 4 in Usage examples section).
 
 #### Optional values for `topicSubscriptions`
 
@@ -364,6 +318,59 @@ topicSubscriptionRules:
       sqlExpression: <string>  
 ```
 
+#### Usage examples
+The following section provides usage examples for the Namespace Topic template.
+
+##### Example 1 : ServiceA in TeamA creates Topic with 1 role assignment
+
+```
+namespaceTopics:
+  name: claim-notify
+  roleAssignments:  
+    - roleName: TopicSender 
+```
+
+##### Example 2 : ServiceB in TeamA needs to receive messages from existing `claim-notify` Topic. Note that `owner` is set to `no`.
+
+```
+namespaceTopics:
+  name: claim-notify
+  owner: 'no'
+  roleAssignments:  
+    - roleName: TopicReceiver     
+```
+
+##### Example 3 : ServiceA in TeamA creates Topic with 1 role assignment, Topic Subscription and Topic Subscription Rule.
+
+```
+namespaceTopics:
+  name: claim-notify
+  roleAssignments:  
+    - roleName: TopicSender 
+  topicSubscriptions:
+    - name: claim-notify-subscription-01
+      topicSubscriptionRules:
+        - name: claim-notify-subscription-rule-01
+          filterType: SqlFilter
+          sqlFilter:
+            sqlExpression: "3=3"   
+        - name: claim-notify-subscription-rule-02
+          filterType: CorrelationFilter
+          sqlFilter:
+            contentType: "testvalue"      
+```
+
+##### Example 4: ServiceB in TeamA creates Topic Subscription in existing Topic.
+
+```
+namespaceTopics:
+  name: claim-notify
+  owner: "no"
+  roleAssignments:  
+    - roleName: TopicReceiver
+  topicSubscriptions:
+    - name: claim-notify-subscription-03   
+```
 
 ### Database for Postgres Flexible server template
 
@@ -392,6 +399,19 @@ postgres:
     collation: <string> 
 ```
 Please note that the postgres DB name is prefixed with `namespace` internally. For example, if the namespace name is "adp-microservice" and you have provided the DB name as "demo-db," then in the postgres server, it creates a database with the name "adp-microservice-demo-db".
+
+#### Usage examples
+The following section provides usage examples for the Flexible-Servers-Db template.
+
+##### Example 1 : ServiceA in TeamA creates `payment` database
+
+```
+postgres:
+  db:
+    name: payment 
+    charset: UTF8
+    collation: en_US.utf8
+```
 
 ### UserAssignedIdentity
 
@@ -431,7 +451,7 @@ userAssignedIdentity:
 
 This template also optionally allows you to create `Federated credentials` for a given User Assigned Identity by providing `federatedCreds` properties in the userAssignedIdentity object.
 
-Below are the minimum values that are required to be set in the parent chart's values.yaml to create a `userAssignedIdentity`, `roleAssignments` and `federatedCreds`.
+Below are the minimum values that are required to be set in the parent chart's values.yaml to create a `userAssignedIdentity` and `federatedCreds`.
 
 ```
 userAssignedIdentity:     
@@ -440,16 +460,16 @@ userAssignedIdentity:
         serviceAccountName: <string>     
 
 ```
+#### Usage examples
+The following section provides usage examples for the UserAssignedIdentity template.
 
-For e.g. The below example will create one userAssignedIdentity, two role assignments, and one federated credential.
+##### Example 1 : The below example will create userAssignedIdentity with one federated credential.
 
 ```
-
 userAssignedIdentity:
   federatedCreds: 
     - namespace: ffc-demo
-      serviceAccountName: ffc-demo    
-                    
+      serviceAccountName: ffc-demo 
 ```
 
 ### Storage Account

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ For instance, in the Dev environment, the storageAccountPrefix is configured as 
 
 ```
 storageAccounts:          <Array of Object>
-  - name: <string>        --Storage account name. Name should be Lowercase letters and numbers and Character limit: 3-24.
+  - name: <string>        --Storage account name. Name should be Lowercase letters and numbers and Maximum character limit is `9`
   - name: <string>
 ```
 
@@ -529,8 +529,8 @@ storageAccounts:          <Array of Object>
 The following values need to be set in the parent chart's `values.yaml` in addition to the globally required values [listed above](#all-template-required-values).
 
 ```
-storageAccounts:                  <Array of Object>
-  - name: <string>                --Storage account name. Name should be lowercase letters and numbers and Character limit: 3-24
+storageAccounts:           <Array of Object>
+  - name: <string>         --Storage account name. Name should be lowercase letters and numbers and Maximum character limit is `9`
   - name: <string>
     blobContainers:
       - name: <string>            --Blob container name. Name should be lowercase and can contain only letters, numbers, and the hyphen/minus (-) character. Character limit: 3-63

--- a/adp-aso-helm-library/Chart.yaml
+++ b/adp-aso-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-aso-helm-library
 description: A Helm chart library that captures general configuration for Azure Service Operator (ASO) resources.
 type: library
-version: 1.0.16
+version: 1.0.17

--- a/adp-aso-helm-library/templates/_helpers.tpl
+++ b/adp-aso-helm-library/templates/_helpers.tpl
@@ -211,6 +211,7 @@ PrivateEndpoint Name.
 
 {{/*
 Get the Private DNS Zone Id.
+Added TEMPORARY values to test dns a record in SND1 environment
 */}}
 {{- define "privateDNSZone.resourceId" -}}
 {{- $ := index . 0 }}
@@ -218,9 +219,9 @@ Get the Private DNS Zone Id.
 {{- $privateDnsZoneName := index . 2 }}
 {{- $location := index . 3 }}
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
-{{- $azrMSTPrivateLinkDNSSubscriptionID := (required (printf $requiredMsg "azrMSTPrivateLinkDNSSubscriptionID") $.Values.azrMSTPrivateLinkDNSSubscriptionID) }}
-{{- $azrMSTPrivateLinkDNSUKSouthResourceGroupName := (required (printf $requiredMsg "azrMSTPrivateLinkDNSUKSouthResourceGroupName") $.Values.azrMSTPrivateLinkDNSUKSouthResourceGroupName) }}
-{{- $azrMSTPrivateLinkDNSUKWestResourceGroupName := (required (printf $requiredMsg "azrMSTPrivateLinkDNSUKWestResourceGroupName") $.Values.azrMSTPrivateLinkDNSUKWestResourceGroupName) }}
+{{- $azrMSTPrivateLinkDNSSubscriptionID := "55f3b8c6-6800-41c7-a40d-2adb5e4e1bd1" }}
+{{- $azrMSTPrivateLinkDNSUKSouthResourceGroupName := "sndadpdnsrg1401" }}
+{{- $azrMSTPrivateLinkDNSUKWestResourceGroupName := "testukwest" }}
 {{- if eq $location "uksouth" }}
 {{- printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s" $azrMSTPrivateLinkDNSSubscriptionID $azrMSTPrivateLinkDNSUKSouthResourceGroupName $privateDnsZoneName }}
 {{- else if eq $location "ukwest" }}

--- a/adp-aso-helm-library/templates/_helpers.tpl
+++ b/adp-aso-helm-library/templates/_helpers.tpl
@@ -230,3 +230,15 @@ Added TEMPORARY values to test dns a record in SND1 environment
 {{- fail (printf "Value for location is not as expected. '%s' is not in the allowed location." $location) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the A record Ip Address if custom resource 'PrivateDnsZonesARecord' exist in cluster
+*/}}
+{{- define "check.ipAddressFromExistingDnsACustomResource" -}}
+{{- $customResourceDnsRecordAName := index . 0 }}
+{{- if (lookup "network.azure.com/v1api20200601" "PrivateDnsZonesARecord" "flux-config" $customResourceDnsRecordAName) }}
+{{- printf (index (lookup "network.azure.com/v1api20200601" "PrivateDnsZonesARecord" "flux-config" $customResourceDnsRecordAName).spec.aRecords 0).ipv4Address }}
+{{- else }}
+{{- printf "" }}
+{{- end }} 
+{{- end }}

--- a/adp-aso-helm-library/templates/_helpers.tpl
+++ b/adp-aso-helm-library/templates/_helpers.tpl
@@ -219,7 +219,7 @@ Added TEMPORARY values to test dns a record in SND1 environment
 {{- $privateDnsZoneName := index . 2 }}
 {{- $location := index . 3 }}
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
-{{- $azrMSTPrivateLinkDNSSubscriptionID := "55f3b8c6-6800-41c7-a40d-2adb5e4e1bd1" }}
+{{- $azrMSTPrivateLinkDNSSubscriptionID := $.Values.subscriptionId }}
 {{- $azrMSTPrivateLinkDNSUKSouthResourceGroupName := "sndadpdnsrg1401" }}
 {{- $azrMSTPrivateLinkDNSUKWestResourceGroupName := "testukwest" }}
 {{- if eq $location "uksouth" }}

--- a/adp-aso-helm-library/templates/_helpers.tpl
+++ b/adp-aso-helm-library/templates/_helpers.tpl
@@ -215,7 +215,6 @@ PrivateEndpoint Name.
 
 {{/*
 Get the Private DNS Zone Id.
-Added TEMPORARY values to test dns a record in SND1 environment
 */}}
 {{- define "privateDNSZone.resourceId" -}}
 {{- $ := index . 0 }}

--- a/adp-aso-helm-library/templates/_helpers.tpl
+++ b/adp-aso-helm-library/templates/_helpers.tpl
@@ -136,7 +136,11 @@ Storage account FullName in Azure
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" $ }}
 {{- $storageAccountPrefix := (required (printf $requiredMsg "storageAccountPrefix") $.Values.storageAccountPrefix) }}
 {{- if $storageAccountPrefix }}
+{{- if le (len $storageAccountName) 9 }}
 {{- (printf "%s%s" $storageAccountPrefix $storageAccountName) | lower }}
+{{- else }}
+{{- fail (printf "The storage account name '%s' is longer than the permitted 9 characters." $storageAccountName) }}
+{{- end }}
 {{- else }}
 {{- printf "this-condition-is-required-for-linting" }}
 {{- end }}
@@ -219,9 +223,9 @@ Added TEMPORARY values to test dns a record in SND1 environment
 {{- $privateDnsZoneName := index . 2 }}
 {{- $location := index . 3 }}
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
-{{- $azrMSTPrivateLinkDNSSubscriptionID := $.Values.subscriptionId }}
-{{- $azrMSTPrivateLinkDNSUKSouthResourceGroupName := "sndadpdnsrg1401" }}
-{{- $azrMSTPrivateLinkDNSUKWestResourceGroupName := "testukwest" }}
+{{- $azrMSTPrivateLinkDNSSubscriptionID := (required (printf $requiredMsg "azrMSTPrivateLinkDNSSubscriptionID") $.Values.azrMSTPrivateLinkDNSSubscriptionID) }}
+{{- $azrMSTPrivateLinkDNSUKSouthResourceGroupName := (required (printf $requiredMsg "azrMSTPrivateLinkDNSUKSouthResourceGroupName") $.Values.azrMSTPrivateLinkDNSUKSouthResourceGroupName) }}
+{{- $azrMSTPrivateLinkDNSUKWestResourceGroupName := (required (printf $requiredMsg "azrMSTPrivateLinkDNSUKWestResourceGroupName") $.Values.azrMSTPrivateLinkDNSUKWestResourceGroupName) }}
 {{- if eq $location "uksouth" }}
 {{- printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s" $azrMSTPrivateLinkDNSSubscriptionID $azrMSTPrivateLinkDNSUKSouthResourceGroupName $privateDnsZoneName }}
 {{- else if eq $location "ukwest" }}

--- a/adp-aso-helm-library/templates/_helpers.tpl
+++ b/adp-aso-helm-library/templates/_helpers.tpl
@@ -128,6 +128,21 @@ Scope for the Storage account roleAssignment
 {{- end }}
 
 {{/*
+Storage account FullName in Azure
+*/}}
+{{- define "storageAccount.fullname" -}}
+{{- $ := index . 0 }}
+{{- $storageAccountName := index . 1 }}
+{{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" $ }}
+{{- $storageAccountPrefix := (required (printf $requiredMsg "storageAccountPrefix") $.Values.storageAccountPrefix) }}
+{{- if $storageAccountPrefix }}
+{{- (printf "%s%s" $storageAccountPrefix $storageAccountName) | lower }}
+{{- else }}
+{{- printf "this-condition-is-required-for-linting" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Storage account metadata FullName
 */}}
 {{- define "storageAccount.metadata.fullname" -}}
@@ -141,6 +156,7 @@ Storage account metadata FullName
 {{- printf "this-condition-is-required-for-linting" }}
 {{- end }}
 {{- end }}
+
 
 {{/*
 default name for StorageAccountsBlobService, StorageAccountsTableService, StorageAccountsFileService, StorageAccountsQueueService

--- a/adp-aso-helm-library/templates/_private-dns-zone-a-record.yaml
+++ b/adp-aso-helm-library/templates/_private-dns-zone-a-record.yaml
@@ -52,6 +52,7 @@ spec:
     armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.table.core.windows.net" "uksouth") }}  
     {{- end }}
   ttl: 3600   
+---  
 {{- end }} 
 {{- end }}  
 {{- end }} 

--- a/adp-aso-helm-library/templates/_private-dns-zone-a-record.yaml
+++ b/adp-aso-helm-library/templates/_private-dns-zone-a-record.yaml
@@ -9,17 +9,22 @@
 {{- $storageAccountFullName :=  include "storageAccount.fullname" (list $ $storageAccountName) }}
 {{- $owner := $storageAccountObj.owner | default "yes" }}
 {{- if eq $owner "yes" }}
+{{- $blobDnsARecordName := printf "privatelink.blob.core.windows.net-%s" $storageAccountFullName }}
 {{- $privateEndpointBlobName :=  include "privateEndpoint.name" (list $ $storageAccountFullName "blob") }}
+{{- $blobDnsARecordIpAddressFromExistingDnsACustomResource := include "check.ipAddressFromExistingDnsACustomResource" (list $blobDnsARecordName) }}
 apiVersion: network.azure.com/v1api20200601
 kind: PrivateDnsZonesARecord
 metadata:
-  name: {{ printf "privatelink.blob.core.windows.net-%s" $storageAccountFullName }}
+  name: {{ $blobDnsARecordName }}
   namespace: {{ required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
   labels:
-    privateEndpointBlobName: {{ $privateEndpointBlobName }}
+    privateEndpointBlobName: {{ $privateEndpointBlobName }}  
+    blobDnsARecordIpAddressFromExistingDnsACustomResource: {{ $blobDnsARecordIpAddressFromExistingDnsACustomResource }} 
 spec:
   aRecords:
-  {{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointBlobName) }}
+  {{- if $blobDnsARecordIpAddressFromExistingDnsACustomResource }}
+  - ipv4Address: {{ $blobDnsARecordIpAddressFromExistingDnsACustomResource }}
+  {{- else if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointBlobName) }}
   - ipv4Address: {{ (index (index (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointBlobName).status.customDnsConfigs 0).ipAddresses 0) }}
   {{- end }} 
   azureName: {{ $storageAccountFullName }}
@@ -29,19 +34,24 @@ spec:
     {{- else }}
     armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.blob.core.windows.net" "uksouth") }}  
     {{- end }}
-  ttl: 3600   
+  ttl: 3600    
 ---
+{{- $tableDnsARecordName := printf "privatelink.table.core.windows.net-%s" $storageAccountFullName }}  
 {{- $privateEndpointTableName :=  include "privateEndpoint.name" (list $ $storageAccountFullName "table") }}
+{{- $tableDnsARecordIpAddressFromExistingDnsACustomResource := include "check.ipAddressFromExistingDnsACustomResource" (list $tableDnsARecordName) }}
 apiVersion: network.azure.com/v1api20200601
 kind: PrivateDnsZonesARecord
 metadata:
-  name: {{ printf "privatelink.table.core.windows.net-%s" $storageAccountFullName }}
+  name: {{ $tableDnsARecordName }}
   namespace: {{ required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
   labels:
     privateEndpointTableName: {{ $privateEndpointTableName }}
+    tableDnsARecordIpAddressFromExistingDnsACustomResource: {{ $tableDnsARecordIpAddressFromExistingDnsACustomResource }}
 spec:
   aRecords:
-  {{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointTableName) }}
+  {{- if $tableDnsARecordIpAddressFromExistingDnsACustomResource }}
+  - ipv4Address: {{ $tableDnsARecordIpAddressFromExistingDnsACustomResource }}
+  {{- else if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointTableName) }}
   - ipv4Address: {{ (index (index (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointTableName).status.customDnsConfigs 0).ipAddresses 0) }}
   {{- end }} 
   azureName: {{ $storageAccountFullName }}

--- a/adp-aso-helm-library/templates/_private-dns-zone-a-record.yaml
+++ b/adp-aso-helm-library/templates/_private-dns-zone-a-record.yaml
@@ -1,0 +1,53 @@
+{{- define "adp-aso-helm-library.private-dns-zone-a-record" -}}
+{{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
+{{- $subscriptionId := required (printf $requiredMsg "subscriptionId") .Values.subscriptionId }} 
+{{- $environment := required (printf $requiredMsg "environment") $.Values.environment | lower }} 
+{{- $fluxConfigNamespace := required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
+{{- $storageAccounts := required (printf $requiredMsg "storageAccounts") .Values.storageAccounts }}
+{{- range $storageAccountObj := .Values.storageAccounts }}
+{{- $storageAccountName :=  required (printf $requiredMsg "storageAccount[].name") $storageAccountObj.name }}
+{{- $storageAccountFullName :=  include "storageAccount.fullname" (list $ $storageAccountName) }}
+{{- $owner := $storageAccountObj.owner | default "yes" }}
+{{- if eq $owner "yes" }}
+{{- $privateEndpointBlobName :=  include "privateEndpoint.name" (list $ $storageAccountFullName "blob") }}
+apiVersion: network.azure.com/v1api20200601
+kind: PrivateDnsZonesARecord
+metadata:
+  name: {{ printf "privatelink.blob.core.windows.net-%s" $storageAccountFullName }}
+  namespace: {{ required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
+spec:
+  aRecords:
+  {{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointBlobName) }}
+  - ipv4Address: {{ (index (index (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointBlobName).status.customDnsConfigs 0).ipAddresses 0) }}
+  {{- end }} 
+  azureName: {{ $storageAccountFullName }}
+  owner:
+    {{- if eq ($storageAccountObj.location | default "uksouth") "uksouth"}}
+    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.blob.core.windows.net" "ukwest") }}  
+    {{- else }}
+    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.blob.core.windows.net" "uksouth") }}  
+    {{- end }}
+  ttl: 3600   
+---
+{{- $privateEndpointTableName :=  include "privateEndpoint.name" (list $ $storageAccountFullName "table") }}
+apiVersion: network.azure.com/v1api20200601
+kind: PrivateDnsZonesARecord
+metadata:
+  name: {{ printf "privatelink.table.core.windows.net-%s" $storageAccountFullName }}
+  namespace: {{ required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
+spec:
+  aRecords:
+  {{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointTableName) }}
+  - ipv4Address: {{ (index (index (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointTableName).status.customDnsConfigs 0).ipAddresses 0) }}
+  {{- end }} 
+  azureName: {{ $storageAccountFullName }}
+  owner:
+    {{- if eq ($storageAccountObj.location | default "uksouth") "uksouth"}}
+    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.table.core.windows.net" "ukwest") }}  
+    {{- else }}
+    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.table.core.windows.net" "uksouth") }}  
+    {{- end }}
+  ttl: 3600   
+{{- end }} 
+{{- end }}  
+{{- end }} 

--- a/adp-aso-helm-library/templates/_private-dns-zone-a-record.yaml
+++ b/adp-aso-helm-library/templates/_private-dns-zone-a-record.yaml
@@ -15,6 +15,8 @@ kind: PrivateDnsZonesARecord
 metadata:
   name: {{ printf "privatelink.blob.core.windows.net-%s" $storageAccountFullName }}
   namespace: {{ required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
+  labels:
+    privateEndpointBlobName: {{ $privateEndpointBlobName }}
 spec:
   aRecords:
   {{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointBlobName) }}
@@ -35,6 +37,8 @@ kind: PrivateDnsZonesARecord
 metadata:
   name: {{ printf "privatelink.table.core.windows.net-%s" $storageAccountFullName }}
   namespace: {{ required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
+  labels:
+    privateEndpointTableName: {{ $privateEndpointTableName }}
 spec:
   aRecords:
   {{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointTableName) }}

--- a/adp-aso-helm-library/templates/_storage-account-blob-service.yaml
+++ b/adp-aso-helm-library/templates/_storage-account-blob-service.yaml
@@ -2,11 +2,11 @@
 {{- $ := index . 0 }}
 {{- $storageAccountObj := index . 1 }}
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
-{{- $storageAccountName := $storageAccountObj.name }}
+{{- $storageAccountFullName := include "storageAccount.fullname" (list $ $storageAccountObj.name) }}
 apiVersion: storage.azure.com/v1api20220901
 kind: StorageAccountsBlobService
 metadata:
-  name: {{ include "storageaccountsService.metadata.defaultName" (list $ $storageAccountName) }}
+  name: {{ include "storageaccountsService.metadata.defaultName" (list $ $storageAccountFullName) }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace | quote }}  
   {{- with $.Values.asoAnnotations }}
   annotations: 
@@ -71,5 +71,5 @@ spec:
   isVersioningEnabled: {{ and $storageAccountObj.storageAccountsBlobService $storageAccountObj.storageAccountsBlobService.isVersioningEnabled | default false }}
   cors: {}
   owner:
-    armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s" $.Values.subscriptionId $.Values.teamResourceGroupName $storageAccountName }} 
+    armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s" $.Values.subscriptionId $.Values.teamResourceGroupName $storageAccountFullName }} 
 {{- end }}

--- a/adp-aso-helm-library/templates/_storage-account-blob-services-container.yaml
+++ b/adp-aso-helm-library/templates/_storage-account-blob-services-container.yaml
@@ -2,12 +2,12 @@
 {{- $ := index . 0 }}
 {{- $storageAccountObj := index . 1 }}
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
-{{- $storageAccountName := $storageAccountObj.name }}
+{{- $storageAccountFullName := include "storageAccount.fullname" (list $ $storageAccountObj.name) }}
 {{- range $storageAccountsBlobServicesContainer := $storageAccountObj.blobContainers }}
 apiVersion: storage.azure.com/v1api20220901
 kind: StorageAccountsBlobServicesContainer
 metadata:
-  name: {{ include "storageAccountsBlobServicesContainer.metadata.fullname" (list $ $storageAccountName $storageAccountsBlobServicesContainer.name) }}
+  name: {{ include "storageAccountsBlobServicesContainer.metadata.fullname" (list $ $storageAccountFullName $storageAccountsBlobServicesContainer.name) }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace | quote }}  
   {{- with $.Values.asoAnnotations }}
   annotations: 
@@ -17,11 +17,11 @@ spec:
   azureName: {{ $storageAccountsBlobServicesContainer.name }}
   publicAccess: {{ $storageAccountsBlobServicesContainer.publicAccess | default "None" }}
   owner:
-    armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default" $.Values.subscriptionId $.Values.teamResourceGroupName $storageAccountName }} 
+    armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default" $.Values.subscriptionId $.Values.teamResourceGroupName $storageAccountFullName }} 
 --- 
 {{- if $storageAccountsBlobServicesContainer.roleAssignments }}    
 --- 
-{{- include "adp-aso-helm-library.storage-account-role-assignment" (list $ $storageAccountsBlobServicesContainer.roleAssignments $storageAccountName $storageAccountsBlobServicesContainer.name "storageContainer") }}   
+{{- include "adp-aso-helm-library.storage-account-role-assignment" (list $ $storageAccountsBlobServicesContainer.roleAssignments $storageAccountFullName $storageAccountsBlobServicesContainer.name "storageContainer") }}   
 {{- end }} 
 {{- end }}
 {{- end }}

--- a/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
+++ b/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
@@ -12,6 +12,7 @@
 {{- $privateEndpointVNetName := required (printf $requiredMsg "virtualNetworkName") $.Values.virtualNetworkName }}
 {{- $privateEndpointSubnetName := required (printf $requiredMsg "privateEndpointSubnetName") $.Values.privateEndpointSubnetName }}
 {{- $fluxConfigNamespace := required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
+{{- $storageAccountFullName := include "storageAccount.fullname" (list $ $storageAccountObj.name) }}
 apiVersion: network.azure.com/v1api20220701
 kind: PrivateEndpoint
 metadata:
@@ -32,7 +33,7 @@ spec:
       description: Auto-Approved
       status: Approved
     privateLinkServiceReference:
-      armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s" $subscriptionId $teamRGName $storageAccountObj.name }} 
+      armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s" $subscriptionId $teamRGName $storageAccountFullName }} 
   subnet:
     reference:
       armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s" $subscriptionId $privateEndpointVnetRGName $privateEndpointVNetName $privateEndpointSubnetName }} 

--- a/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
+++ b/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
@@ -18,14 +18,10 @@ kind: PrivateEndpoint
 metadata:
   name: {{ $privateEndpointName }}
   namespace: {{ $fluxConfigNamespace }}
+  {{- with $.Values.asoAnnotations }}
   annotations: 
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  labels: 
-    {{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointName) }}
-    ipAddress1: {{ (index (index (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointName).status.customDnsConfigs 0).ipAddresses 0) }}
-    {{- else }}
-    ipAddress2: "0.0.0.0"
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   azureName: {{ $privateEndpointName }}
   customNetworkInterfaceName: {{ printf "%s-nic" $privateEndpointName }}
@@ -54,8 +50,10 @@ kind: PrivateEndpointsPrivateDnsZoneGroup
 metadata:
   name: {{ printf "%s-default" $privateEndpointName }}
   namespace: {{ required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
+  {{- with $.Values.asoAnnotations }}
   annotations: 
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   azureName: default
   owner:

--- a/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
+++ b/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
@@ -44,7 +44,7 @@ spec:
   owner:
     armId: {{ printf "/subscriptions/%s/resourceGroups/%s" $subscriptionId $teamRGName }}     
 ---
-{{- if ne $environment "snd11" }}
+{{- if ne $environment "snd" }}
 apiVersion: network.azure.com/v1api20220701
 kind: PrivateEndpointsPrivateDnsZoneGroup
 metadata:

--- a/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
+++ b/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
@@ -20,6 +20,12 @@ metadata:
   namespace: {{ $fluxConfigNamespace }}
   annotations: 
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
+  labels: 
+    {{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointName) }}
+    ipAddress1: {{ (index (index (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointName).status.customDnsConfigs 0).ipAddresses 0) }}
+    {{- else }}
+    ipAddress2: "0.0.0.0"
+    {{- end }}
 spec:
   azureName: {{ $privateEndpointName }}
   customNetworkInterfaceName: {{ printf "%s-nic" $privateEndpointName }}
@@ -42,7 +48,7 @@ spec:
   owner:
     armId: {{ printf "/subscriptions/%s/resourceGroups/%s" $subscriptionId $teamRGName }}     
 ---
-{{- if ne $environment "snd" }}
+{{- if ne $environment "snd11" }}
 apiVersion: network.azure.com/v1api20220701
 kind: PrivateEndpointsPrivateDnsZoneGroup
 metadata:
@@ -64,6 +70,39 @@ spec:
   - name: privatelink-table-core-windows-net
     privateDnsZoneReference:
       armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.table.core.windows.net" ($storageAccountObj.location | default "uksouth")) }}
-  {{- end }}     
+  {{- end }}    
+---
+{{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointName) }}
+apiVersion: network.azure.com/v1api20200601
+kind: PrivateDnsZonesARecord
+metadata:
+  {{- if eq $privateEndpointSubResource "blob"}}
+  name: {{ printf "privatelink.blob.core.windows.net-%s" $storageAccountFullName }}
+  {{- end }} 
+  {{- if eq $privateEndpointSubResource "table"}}
+  name: {{ printf "privatelink.table.core.windows.net-%s" $storageAccountFullName }}
+  {{- end }}
+  namespace: {{ required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
+spec:
+  aRecords:
+  - ipv4Address: {{ (index (index (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointName).status.customDnsConfigs 0).ipAddresses 0) }}
+  azureName: {{ $storageAccountFullName }}
+  owner:
+    {{- if eq $privateEndpointSubResource "blob"}}
+    {{- if eq ($storageAccountObj.location | default "uksouth") "uksouth"}}
+    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.blob.core.windows.net" "ukwest") }}  
+    {{- else }}
+    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.blob.core.windows.net" "uksouth") }}  
+    {{- end }}
+    {{- end }}
+    {{- if eq $privateEndpointSubResource "table"}}
+    {{- if eq ($storageAccountObj.location | default "uksouth") "uksouth"}}
+    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.table.core.windows.net" "ukwest") }}  
+    {{- else }}
+    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.table.core.windows.net" "uksouth") }}  
+    {{- end }}
+    {{- end }}
+  ttl: 3600   
+{{- end }}  
 {{- end }}   
 {{- end }} 

--- a/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
+++ b/adp-aso-helm-library/templates/_storage-account-private-endpoint.yaml
@@ -71,38 +71,5 @@ spec:
     privateDnsZoneReference:
       armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.table.core.windows.net" ($storageAccountObj.location | default "uksouth")) }}
   {{- end }}    
----
-{{- if (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointName) }}
-apiVersion: network.azure.com/v1api20200601
-kind: PrivateDnsZonesARecord
-metadata:
-  {{- if eq $privateEndpointSubResource "blob"}}
-  name: {{ printf "privatelink.blob.core.windows.net-%s" $storageAccountFullName }}
-  {{- end }} 
-  {{- if eq $privateEndpointSubResource "table"}}
-  name: {{ printf "privatelink.table.core.windows.net-%s" $storageAccountFullName }}
-  {{- end }}
-  namespace: {{ required (printf $requiredMsg "fluxConfigNamespace") $.Values.fluxConfigNamespace }}
-spec:
-  aRecords:
-  - ipv4Address: {{ (index (index (lookup "network.azure.com/v1api20220701" "PrivateEndpoint" "flux-config" $privateEndpointName).status.customDnsConfigs 0).ipAddresses 0) }}
-  azureName: {{ $storageAccountFullName }}
-  owner:
-    {{- if eq $privateEndpointSubResource "blob"}}
-    {{- if eq ($storageAccountObj.location | default "uksouth") "uksouth"}}
-    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.blob.core.windows.net" "ukwest") }}  
-    {{- else }}
-    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.blob.core.windows.net" "uksouth") }}  
-    {{- end }}
-    {{- end }}
-    {{- if eq $privateEndpointSubResource "table"}}
-    {{- if eq ($storageAccountObj.location | default "uksouth") "uksouth"}}
-    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.table.core.windows.net" "ukwest") }}  
-    {{- else }}
-    armId: {{ include "privateDNSZone.resourceId" (list $ ($environment) "privatelink.table.core.windows.net" "uksouth") }}  
-    {{- end }}
-    {{- end }}
-  ttl: 3600   
-{{- end }}  
 {{- end }}   
 {{- end }} 

--- a/adp-aso-helm-library/templates/_storage-account-table-services-table.yaml
+++ b/adp-aso-helm-library/templates/_storage-account-table-services-table.yaml
@@ -2,12 +2,12 @@
 {{- $ := index . 0 }}
 {{- $storageAccountObj := index . 1 }}
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
-{{- $storageAccountName := $storageAccountObj.name }}
+{{- $storageAccountFullName := include "storageAccount.fullname" (list $ $storageAccountObj.name) }}
 {{- range $storageAccountsTableServicesTable := $storageAccountObj.tables }}
 apiVersion: storage.azure.com/v1api20220901
 kind: StorageAccountsTableServicesTable
 metadata:
-  name: {{ include "storageAccountsTableServicesTable.metadata.fullname" (list $ $storageAccountName $storageAccountsTableServicesTable.name) }}
+  name: {{ include "storageAccountsTableServicesTable.metadata.fullname" (list $ $storageAccountFullName $storageAccountsTableServicesTable.name) }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace | quote }}  
   {{- with $.Values.asoAnnotations }}
   annotations: 
@@ -16,11 +16,11 @@ metadata:
 spec:
   azureName: {{ $storageAccountsTableServicesTable.name }}
   owner:
-    armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/tableServices/default" $.Values.subscriptionId $.Values.teamResourceGroupName $storageAccountName }} 
+    armId: {{ printf "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/tableServices/default" $.Values.subscriptionId $.Values.teamResourceGroupName $storageAccountFullName }} 
 --- 
 {{- if $storageAccountsTableServicesTable.roleAssignments }}    
 --- 
-{{- include "adp-aso-helm-library.storage-account-role-assignment" (list $ $storageAccountsTableServicesTable.roleAssignments $storageAccountName $storageAccountsTableServicesTable.name "storageTable") }}   
+{{- include "adp-aso-helm-library.storage-account-role-assignment" (list $ $storageAccountsTableServicesTable.roleAssignments $storageAccountFullName $storageAccountsTableServicesTable.name "storageTable") }}   
 {{- end }} 
 {{- end }}
 {{- end }}

--- a/adp-aso-helm-library/templates/_storage-account.yaml
+++ b/adp-aso-helm-library/templates/_storage-account.yaml
@@ -48,7 +48,7 @@ spec:
   minimumTlsVersion: "TLS1_2"
   networkAcls:
     bypass: AzureServices
-    defaultAction: Allow
+    defaultAction: Deny
     {{- if and $storageAccount.networkAcls $storageAccount.networkAcls.ipRules }}
     ipRules: 
     {{- range $storageAccount.networkAcls.ipRules }}

--- a/adp-aso-helm-library/templates/_storage-account.yaml
+++ b/adp-aso-helm-library/templates/_storage-account.yaml
@@ -6,19 +6,20 @@
 {{- $storageAccountObject := required (printf $requiredMsg "storageAccounts") .Values.storageAccounts }}
 {{- range $storageAccount := .Values.storageAccounts }}
 {{- $storageAccountName :=  required (printf $requiredMsg "storageAccount[].name") $storageAccount.name }}
+{{- $storageAccountFullName :=  include "storageAccount.fullname" (list $ $storageAccountName) }}
 {{- $owner := $storageAccount.owner | default "yes" }}
 {{- if eq $owner "yes" }}
 apiVersion: storage.azure.com/v1api20220901
 kind: StorageAccount
 metadata:
-  name: {{ include "storageAccount.metadata.fullname" (list $ $storageAccountName) }}
+  name: {{ include "storageAccount.metadata.fullname" (list $ $storageAccountFullName) }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace | quote }}  
   {{- with $.Values.asoAnnotations }}
   annotations: 
     {{- toYaml . | nindent 4 }}
   {{- end }}  
 spec:
-  azureName: {{ $storageAccountName }}
+  azureName: {{ $storageAccountFullName }}
   accessTier: {{ $storageAccount.accessTier | default "Hot" }}
   kind: StorageV2
   sku:
@@ -66,9 +67,9 @@ spec:
   owner:
     armId: {{ printf "/subscriptions/%s/resourceGroups/%s" $subscriptionId $teamRGName }}  
 ---
-{{- include "adp-aso-helm-library.storage-account-private-endpoint" (list $ $storageAccount $storageAccount.name "blob") }} 
+{{- include "adp-aso-helm-library.storage-account-private-endpoint" (list $ $storageAccount $storageAccountFullName "blob") }} 
 ---
-{{- include "adp-aso-helm-library.storage-account-private-endpoint" (list $ $storageAccount $storageAccount.name "table") }}
+{{- include "adp-aso-helm-library.storage-account-private-endpoint" (list $ $storageAccount $storageAccountFullName "table") }}
 {{- end }} 
 ---  
 {{- include "adp-aso-helm-library.storage-account-blob-service" (list $ .) }} 

--- a/adp-aso-helm-library/templates/_storage-account.yaml
+++ b/adp-aso-helm-library/templates/_storage-account.yaml
@@ -2,7 +2,7 @@
 {{- $requiredMsg := include "adp-aso-helm-library.default-check-required-msg" . }}
 {{- $teamRGName := required (printf $requiredMsg "teamResourceGroupName") .Values.teamResourceGroupName }}
 {{- $subscriptionId := required (printf $requiredMsg "subscriptionId") .Values.subscriptionId }} 
-{{- $environment := required (printf $requiredMsg "environment") $.Values.environment }} 
+{{- $environment := required (printf $requiredMsg "environment") $.Values.environment | lower }} 
 {{- $storageAccountObject := required (printf $requiredMsg "storageAccounts") .Values.storageAccounts }}
 {{- range $storageAccount := .Values.storageAccounts }}
 {{- $storageAccountName :=  required (printf $requiredMsg "storageAccount[].name") $storageAccount.name }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:

- This PR is to add StorageAccountPrefix to StorageAccount Name
- Updated readme documentation with examples
- storage account length check validation

Relates to ADO Work Item [AB#306948](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/306948)


# **Special notes for your reviewer**
Below PR is related to this change:
[*Any specific actions or notes on review?*](https://github.com/DEFRA/adp-flux-services/pull/55)

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [x] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)