### PR TITLE
337727: TopicSubscription name prefix with namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ And the following user input values are used for demonstration purposes:
 | NamespacesQueue | {namespace}-{QueueName} | ffc-demo-queue01 |	{namespace}-{QueueName} | ffc-demo-queue01 |
 | Queue RoleAssignment | NA | NA |	{userassignedidentityName}-{QueueName}-{RoleName}-rbac-{index} | sndadpinfmi1401-ffc-demo-web-ffc-demo-queue01-queuereceiver-rbac-0 |
 | NamespacesTopic | {namespace}-{TopicName} | ffc-demo-topic01 |	{namespace}-{TopicName} | ffc-demo-topic01 |
-| NamespacesTopicsSubscription | {TopicSubName} | topicSub01 |	{namespace}-{TopicName}-{TopicSubName}-subscription | ffc-demo-topic01-topicsub01-subscription |
+| NamespacesTopicsSubscription | {namespace}-{TopicSubName} | ffc-demo-topicSub01 |	{namespace}-{TopicName}-{TopicSubName}-subscription | ffc-demo-topic01-topicsub01-subscription |
 | Topic RoleAssignment | NA | NA |	{userassignedidentityName}-{TopicName}-{RoleName}-rbac-{index} | sndadpinfmi1401-ffc-demo-web-ffc-demo-topic01-topicreceiver-rbac-0 |
 | Postgres Database | {namespace}-{DatabaseName} | ffc-demo-claim | {postgresServerName}-{namespace}-{DatabaseName} | sndadpdbsps1401-ffc-demo-claim |
 | Manage Idenitty | {teamMIPrefix}-{serviceName} | sndadpinfmi1401-ffc-demo-web |	{teamMIPrefix}-{serviceName} | sndadpinfmi1401-ffc-demo-web |

--- a/adp-aso-helm-library/Chart.yaml
+++ b/adp-aso-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-aso-helm-library
 description: A Helm chart library that captures general configuration for Azure Service Operator (ASO) resources.
 type: library
-version: 1.0.18
+version: 1.0.19

--- a/adp-aso-helm-library/templates/_namespace-topic-subscription.yaml
+++ b/adp-aso-helm-library/templates/_namespace-topic-subscription.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ $topicSubscriptionName }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace | quote }}  
 spec:
-  azureName: {{ $namespaceTopicSubscription.name }}
+  azureName: {{printf "%s-%s" $.Values.namespace $namespaceTopicSubscription.name }}
   deadLetteringOnFilterEvaluationExceptions: {{ $namespaceTopicSubscription.deadLetteringOnFilterEvaluationExceptions | default false }}
   deadLetteringOnMessageExpiration: {{ $namespaceTopicSubscription.deadLetteringOnMessageExpiration | default false }}
   defaultMessageTimeToLive: {{ $namespaceTopicSubscription.defaultMessageTimeToLive | default "P14D" | quote }}

--- a/adp-aso-helm-library/templates/_namespace-topic-subscription.yaml
+++ b/adp-aso-helm-library/templates/_namespace-topic-subscription.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ $topicSubscriptionName }}
   namespace: {{ required (printf $requiredMsg "namespace") $.Values.namespace | quote }}  
 spec:
-  azureName: {{printf "%s-%s" $.Values.namespace $namespaceTopicSubscription.name }}
+  azureName: {{ include "resource.fullname" (list $ (required (printf $requiredMsg "namespaceTopicSubscription.name") $namespaceTopicSubscription.name)) }}
   deadLetteringOnFilterEvaluationExceptions: {{ $namespaceTopicSubscription.deadLetteringOnFilterEvaluationExceptions | default false }}
   deadLetteringOnMessageExpiration: {{ $namespaceTopicSubscription.deadLetteringOnMessageExpiration | default false }}
   defaultMessageTimeToLive: {{ $namespaceTopicSubscription.defaultMessageTimeToLive | default "P14D" | quote }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
@DaRoszko 
TopicSubscription name prefix with namespace
Relates to ADO Work Item [AB#337727](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/337727)

# **Special notes for your reviewer**
PLEASE NOTE:
Updating the AzureName property is not allowed. I manually removed the existing  NamespacesTopicsSubscription CRD resources in the cluster. Subsequently, Flux reconciliation generated NamespacesTopicsSubscription with the intended naming conventions.

# Testing
Tested with 'ffc-demo-payment-service'
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=500227&view=results

And can see latest infra helm chart is pushed to ACR
![image](https://github.com/DEFRA/adp-aso-helm-library/assets/89150034/6e1801ac-6bc2-4cf2-bc3c-2da142a7a017)

TopicSubscription resource in Azure with new naming convention:
![image](https://github.com/DEFRA/adp-aso-helm-library/assets/89150034/925578f8-37b5-458b-b0c4-8caf692d409b)

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)